### PR TITLE
Create .editorconfig with 4 spaces for jsonnet

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{json,jsonnet}]
+indent_style = spaces
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
I think it could be helpful to have this editorconfig for users that have no experience with jsonnet.