### PR TITLE
dashboards: Add units to statefulset and deployment dashboards

### DIFF
--- a/src/kubernetes-jsonnet/grafana/configs/dashboard-definitions/deployments-dashboard.libsonnet
+++ b/src/kubernetes-jsonnet/grafana/configs/dashboard-definitions/deployments-dashboard.libsonnet
@@ -13,6 +13,7 @@ local cpuStat = numbersinglestat.new(
         "sum(rate(container_cpu_usage_seconds_total{namespace=\"$deployment_namespace\",pod_name=~\"$deployment_name.*\"}[3m]))",
     )
     .withSpanSize(4)
+    .withPostfix("cores")
     .withSparkline();
 
 local memoryStat = numbersinglestat.new(
@@ -20,6 +21,7 @@ local memoryStat = numbersinglestat.new(
         "sum(container_memory_usage_bytes{namespace=\"$deployment_namespace\",pod_name=~\"$deployment_name.*\"}) / 1024^3",
     )
     .withSpanSize(4)
+    .withPostfix("GB")
     .withSparkline();
 
 local networkStat = numbersinglestat.new(
@@ -27,6 +29,7 @@ local networkStat = numbersinglestat.new(
         "sum(rate(container_network_transmit_bytes_total{namespace=\"$deployment_namespace\",pod_name=~\"$deployment_name.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$deployment_namespace\",pod_name=~\"$deployment_name.*\"}[3m]))",
     )
     .withSpanSize(4)
+    .withPostfix("Bps")
     .withSparkline();
 
 local overviewRow = row.new()

--- a/src/kubernetes-jsonnet/grafana/configs/dashboard-definitions/promgrafonnet/numbersinglestat.libsonnet
+++ b/src/kubernetes-jsonnet/grafana/configs/dashboard-definitions/promgrafonnet/numbersinglestat.libsonnet
@@ -34,6 +34,9 @@ local prometheus = grafana.prometheus;
             withSpanSize(size):: self {
                     span: size,
                 },
+            withPostfix(postfix):: self {
+                    postfix: postfix,
+                },
             withSparkline():: self {
                     sparkline: {
                         show: true,

--- a/src/kubernetes-jsonnet/grafana/configs/dashboard-definitions/statefulset-dashboard.libsonnet
+++ b/src/kubernetes-jsonnet/grafana/configs/dashboard-definitions/statefulset-dashboard.libsonnet
@@ -13,6 +13,7 @@ local cpuStat = numbersinglestat.new(
         "sum(rate(container_cpu_usage_seconds_total{namespace=\"$statefulset_namespace\",pod_name=~\"$statefulset_name.*\"}[3m]))",
     )
     .withSpanSize(4)
+    .withPostfix("cores")
     .withSparkline();
 
 local memoryStat = numbersinglestat.new(
@@ -20,6 +21,7 @@ local memoryStat = numbersinglestat.new(
         "sum(container_memory_usage_bytes{namespace=\"$statefulset_namespace\",pod_name=~\"$statefulset_name.*\"}) / 1024^3",
     )
     .withSpanSize(4)
+    .withPostfix("GB")
     .withSparkline();
 
 local networkStat = numbersinglestat.new(
@@ -27,6 +29,7 @@ local networkStat = numbersinglestat.new(
         "sum(rate(container_network_transmit_bytes_total{namespace=\"$statefulset_namespace\",pod_name=~\"$statefulset_name.*\"}[3m])) + sum(rate(container_network_receive_bytes_total{namespace=\"$statefulset_namespace\",pod_name=~\"$statefulset_name.*\"}[3m]))",
     )
     .withSpanSize(4)
+    .withPostfix("Bps")
     .withSparkline();
 
 local overviewRow = row.new()


### PR DESCRIPTION
Small improvement (which was previously present in the kube-prometheus dashboards) that displays the units of the cpu, memory and network panels of deployment and statefulset dashboards.

@metalmatze 