### PR TITLE
Consume Grafana configuration as a secret

### DIFF
--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -29,9 +29,9 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
   grafanaDashboards: {},
   grafana+: {
     [if $._config.grafana.config != null then 'config']:
-      local configMap = k.core.v1.configMap;
-      configMap.new('grafana-config', { 'grafana.ini': std.manifestIni($._config.grafana.config) }) +
-      configMap.mixin.metadata.withNamespace($._config.namespace),
+      local secret = k.core.v1.secret;
+      secret.new('grafana-config', { 'grafana.ini': std.base64(std.manifestIni($._config.grafana.config)) }) +
+      secret.mixin.metadata.withNamespace($._config.namespace),
     dashboardDefinitions:
       local configMap = k.core.v1.configMap;
       [
@@ -78,8 +78,8 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       local podLabels = { app: 'grafana' };
 
       local configVolumeName = 'grafana-config';
-      local configConfigMapName = 'grafana-config';
-      local configVolume = volume.withName(configVolumeName) + volume.mixin.configMap.withName(configConfigMapName);
+      local configSecretName = 'grafana-config';
+      local configVolume = volume.withName(configVolumeName) + volume.mixin.secret.withSecretName(configSecretName);
       local configVolumeMount = containerVolumeMount.new(configVolumeName, '/etc/grafana');
 
       local storageVolumeName = 'grafana-storage';


### PR DESCRIPTION
As mentioned in #25, Grafana configuration may contain sensitive information such as the admin username and password, OIDC secrets, etc. This PR saves the configuration as a secret instead of a configMap.