### PR TITLE
Enable Grafana config merging

### DIFF
--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -23,14 +23,14 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
         version: 1,
         editable: false,
       }],
-      config: null,
+      config: {},
       ldap: null,
       plugins: [],
     },
   },
   grafanaDashboards: {},
   grafana+: {
-    [if $._config.grafana.config != null then 'config']:
+    [if std.length($._config.grafana.config) > 0 then 'config']:
       local secret = k.core.v1.secret;
       local grafanaConfig = { 'grafana.ini': std.base64(std.manifestIni($._config.grafana.config)) } +
                             if $._config.grafana.ldap != null then { 'ldap.toml': std.base64($._config.grafana.ldap) } else {};


### PR DESCRIPTION
Per [kube-prometheus PR](https://github.com/coreos/prometheus-operator/pull/2026#discussion_r226842700) it would be preferable to have pluses all the way down for `_config+::` items.
Currently if we try to use + we get the error:
`RUNTIME ERROR: binary operator + requires matching types, got null and object.`

For example, instead of:
```
                   _config+:: {
                     namespace: 'monitoring-grafana',
                     grafana+:: {
                       config: {
```

Do:
```
                   _config+:: {
                     namespace: 'monitoring-grafana',
                     grafana+:: {
                       config+: {
```

Prometheus and Alertmanager in the kube-prometheus both require use of `+` to extend `_config`.