### PR TITLE
Fix: the namespace in Url of Prometheus datasource

### DIFF
--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -19,7 +19,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
         type: 'prometheus',
         access: 'proxy',
         orgId: 1,
-        url: 'http://prometheus-k8s.monitoring.svc:9090',
+        url: 'http://prometheus-k8s.' + $._config.namespace + '.svc:9090',
         version: 1,
         editable: false,
       }],


### PR DESCRIPTION
### What this pull request do
When I try to build and deploy `prometheus-operator` with the following `example.json` file, I found my grafana still access the prometheus with `prometheus-k8s.monitoring.svc:9090` instead of `prometheus-k8s.kube-system.svc:9090`. I think this PR might fix that.
```
$ cat example.json 
local kp = (import 'kube-prometheus/kube-prometheus.libsonnet') + {
  _config+:: {
    namespace: 'kube-system',
  },
};

{ ['00namespace-' + name]: kp.kubePrometheus[name] for name in std.objectFields(kp.kubePrometheus) } +
{ ['0prometheus-operator-' + name]: kp.prometheusOperator[name] for name in std.objectFields(kp.prometheusOperator) } +
{ ['node-exporter-' + name]: kp.nodeExporter[name] for name in std.objectFields(kp.nodeExporter) } +
{ ['kube-state-metrics-' + name]: kp.kubeStateMetrics[name] for name in std.objectFields(kp.kubeStateMetrics) } +
{ ['alertmanager-' + name]: kp.alertmanager[name] for name in std.objectFields(kp.alertmanager) } +
{ ['prometheus-' + name]: kp.prometheus[name] for name in std.objectFields(kp.prometheus) } +
{ ['prometheus-adapter-' + name]: kp.prometheusAdapter[name] for name in std.objectFields(kp.prometheusAdapter) } +
{ ['grafana-' + name]: kp.grafana[name] for name in std.objectFields(kp.grafana) }

$ ./build.sh 
+ set -o pipefail
+ rm -rf manifests
+ mkdir manifests
+ jsonnet -J vendor -m manifests example.json
+ xargs '-I{}' sh -c 'cat {} | gojsontoyaml > {}.yaml; rm -f {}' -- '{}'

$ cat manifests/grafana-dashboardDatasources.yaml|grep prome|awk '{print $2}'|base64 -d
{
    "apiVersion": 1,
    "datasources": [
        {
            "access": "proxy",
            "editable": false,
            "name": "prometheus",
            "orgId": 1,
            "type": "prometheus",
            "url": "http://prometheus-k8s.monitoring.svc:9090",
            "version": 1
        }
    ]
}# 
```
