### PR TITLE
Add ability to configure annotations on service

### DIFF
--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -26,6 +26,9 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
       config: {},
       ldap: null,
       plugins: [],
+      service: {
+        annotations: null
+      },
     },
   },
   grafanaDashboards: {},
@@ -66,7 +69,10 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
 
       service.new('grafana', $.grafana.deployment.spec.selector.matchLabels, grafanaServiceNodePort) +
       service.mixin.metadata.withLabels({ app: 'grafana' }) +
-      service.mixin.metadata.withNamespace($._config.namespace),
+      service.mixin.metadata.withNamespace($._config.namespace) +
+      if $._config.grafana.service.annotations != null 
+        then service.mixin.metadata.withAnnotations($._config.grafana.service.annotations) 
+        else {},
     serviceAccount:
       local serviceAccount = k.core.v1.serviceAccount;
       serviceAccount.new('grafana') +


### PR DESCRIPTION
I needed this to put the service behind an Identity Aware Proxy in GCP

ksonnet newbie - apologies if I've done something silly