### PR TITLE
Remove static default Grafana version

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 local grafana = ((import 'grafana/grafana.libsonnet') + {
                    _config+:: {
                      namespace: 'monitoring-grafana',
+                     versions+: {
+                       grafana: '5.4.3',
+                     },
                    },
                  }).grafana;
 

--- a/examples/basic.jsonnet
+++ b/examples/basic.jsonnet
@@ -5,6 +5,9 @@ local servicePort = k.core.v1.service.mixin.spec.portsType;
 local grafana = ((import 'grafana/grafana.libsonnet') + {
                    _config+:: {
                      namespace: 'monitoring-grafana',
+                     versions+: {
+                       grafana: '5.4.3',
+                     },
                    },
                  }).grafana;
 

--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -5,7 +5,7 @@ local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
     namespace: 'default',
 
     versions+:: {
-      grafana: '5.2.4',
+      grafana: 'latest',
     },
 
     imageRepos+:: {


### PR DESCRIPTION
The expectation is that a downstream should set the version and this package should be able to handle multiple versions.

@metalmatze 