### PR TITLE
Add support for notifiers provisioning

### DIFF
--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -23,6 +23,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         version: 1,
         editable: false,
       }],
+      notifiers: [],
       config: {},
       ldap: null,
       plugins: [],
@@ -60,6 +61,13 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       secret.new('grafana-datasources', { 'datasources.yaml': std.base64(std.manifestJsonEx({
         apiVersion: 1,
         datasources: $._config.grafana.datasources,
+      }, '    ')) }) +
+      secret.mixin.metadata.withNamespace($._config.namespace),
+    [if std.length($._config.grafana.notifiers) > 0 then 'notifiers']:
+      local secret = k.core.v1.secret;
+      secret.new('grafana-notifiers', { 'notifiers.yaml': std.base64(std.manifestJsonEx({
+        apiVersion: 1,
+        notifiers: $._config.grafana.notifiers,
       }, '    ')) }) +
       secret.mixin.metadata.withNamespace($._config.namespace),
     service:
@@ -107,12 +115,21 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       local dashboardsVolume = volume.withName(dashboardsVolumeName) + volume.mixin.configMap.withName(dashboardsConfigMapName);
       local dashboardsVolumeMount = containerVolumeMount.new(dashboardsVolumeName, '/etc/grafana/provisioning/dashboards');
 
+      local hasNotifiers = std.objectHas($.grafana, 'notifiers');
+      local notifiersVolumeName = 'grafana-notifiers';
+      local notifiersSecretName = 'grafana-notifiers';
+      local notifiersVolume = volume.withName(notifiersVolumeName) + volume.mixin.secret.withSecretName(notifiersSecretName);
+      local notifiersVolumeMount = containerVolumeMount.new(notifiersVolumeName, '/etc/grafana/provisioning/notifiers');
+      local notifiersVolumes = if hasNotifiers then [notifiersVolume] else [];
+      local notifiersVolumeMounts = if hasNotifiers then [notifiersVolumeMount] else [];
+
       local volumeMounts =
         [
           storageVolumeMount,
           datasourcesVolumeMount,
           dashboardsVolumeMount,
         ] +
+        notifiersVolumeMounts +
         [
           local dashboardName = std.strReplace(name, '.json', '');
           containerVolumeMount.new('grafana-dashboard-' + dashboardName, '/grafana-dashboard-definitions/0/' + dashboardName)
@@ -126,6 +143,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           datasourcesVolume,
           dashboardsVolume,
         ] +
+        notifiersVolumes +
         [
           local dashboardName = 'grafana-dashboard-' + std.strReplace(name, '.json', '');
           volume.withName(dashboardName) +


### PR DESCRIPTION
This PR adds support for notifiers provisioning (= notification channels)
https://grafana.com/docs/administration/provisioning/#alert-notification-channels

While `notifiers` is left empty, it does not modify anything.
If `notifier` is not empty, it generates a `Secret` and mounts it as a volume, like for datasources.