### PR TITLE
Support Prometheus name other than k8s

### DIFF
--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -12,6 +12,10 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       grafana: 'grafana/grafana',
     },
 
+    prometheus+:: {
+      name: 'k8s',
+    },
+
     grafana+:: {
       dashboards: {},
       datasources: [{
@@ -19,7 +23,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
         type: 'prometheus',
         access: 'proxy',
         orgId: 1,
-        url: 'http://prometheus-k8s.' + $._config.namespace + '.svc:9090',
+        url: 'http://prometheus-' + $._config.prometheus.name + '.' + $._config.namespace + '.svc:9090',
         version: 1,
         editable: false,
       }],


### PR DESCRIPTION
In `kube-prometheus`, the name of the Prometheus instance can be set
with `_config.prometheus.name`, which defaults to `k8s`.

This commit uses that variable to construct the datasource URL, instead
of assuming the default `k8s` value was used.