### PR TITLE
add non-ascii base64 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ install:
 - mkdir -p tmp && cd tmp && wget https://github.com/google/jsonnet/archive/v0.14.0.tar.gz &&
     tar xvfz v0.14.0.tar.gz &&
     cd jsonnet-0.14.0 &&
-    make && mv jsonnet $HOME/gopath/bin && cd .. && rm -rf tmp && cd $TRAVIS_BUILD_DIR
+    make && mv jsonnet jsonnetfmt $HOME/gopath/bin && cd .. && rm -rf tmp && cd $TRAVIS_BUILD_DIR
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 install:
-- mkdir -p tmp && cd tmp && wget https://github.com/google/jsonnet/archive/v0.10.0.tar.gz &&
-    tar xvfz v0.10.0.tar.gz &&
-    cd jsonnet-0.10.0 &&
+- mkdir -p tmp && cd tmp && wget https://github.com/google/jsonnet/archive/v0.14.0.tar.gz &&
+    tar xvfz v0.14.0.tar.gz &&
+    cd jsonnet-0.14.0 &&
     make && mv jsonnet $HOME/gopath/bin && cd .. && rm -rf tmp && cd $TRAVIS_BUILD_DIR
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 fmt:
 	@echo -e "\033[1m>> Formatting all jsonnet files\033[0m"
-	find -iname '*.libsonnet' | awk '{print $1}' | xargs jsonnet fmt -i $1
+	find -iname '*.libsonnet' | awk '{print $1}' | xargs jsonnetfmt -i $1
 
 generate: fmt docs
 	git diff --exit-code

--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -41,8 +41,8 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
   grafana+: {
     [if std.length($._config.grafana.config) > 0 then 'config']:
       local secret = k.core.v1.secret;
-      local grafanaConfig = { 'grafana.ini': std.base64(std.manifestIni($._config.grafana.config)) } +
-                            if $._config.grafana.ldap != null then { 'ldap.toml': std.base64($._config.grafana.ldap) } else {};
+      local grafanaConfig = { 'grafana.ini': std.base64(std.encodeUTF8(std.manifestIni($._config.grafana.config))) } +
+                            if $._config.grafana.ldap != null then { 'ldap.toml': std.base64(std.encodeUTF8($._config.grafana.ldap)) } else {};
       secret.new('grafana-config', grafanaConfig) +
       secret.mixin.metadata.withNamespace($._config.namespace),
     dashboardDefinitions:
@@ -62,10 +62,10 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       configMap.mixin.metadata.withNamespace($._config.namespace),
     dashboardDatasources:
       local secret = k.core.v1.secret;
-      secret.new('grafana-datasources', { 'datasources.yaml': std.base64(std.manifestJsonEx({
+      secret.new('grafana-datasources', { 'datasources.yaml': std.base64(std.encodeUTF8(std.manifestJsonEx({
         apiVersion: 1,
         datasources: $._config.grafana.datasources,
-      }, '    ')) }) +
+      }, '    '))) }) +
       secret.mixin.metadata.withNamespace($._config.namespace),
     service:
       local service = k.core.v1.service;


### PR DESCRIPTION
when has non-ascii in config, std.base64 will failed.
e.g. bind_dn with Chinese in ldap.toml.


https://github.com/google/jsonnet/issues/575
https://github.com/google/jsonnet/pull/577