### PR TITLE
Improve Performance incase of raw Json from grafana is added

### DIFF
--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -58,7 +58,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       local configMap = k.core.v1.configMap;
       [
         local dashboardName = 'grafana-dashboard-' + std.strReplace(name, '.json', '');
-        configMap.new(dashboardName, { [name]: $._config.grafana.rawDashboards[name]}) +
+        configMap.new(dashboardName, { [name]: $._config.grafana.rawDashboards[name] }) +
         configMap.mixin.metadata.withNamespace($._config.namespace)
 
         for name in std.objectFields($._config.grafana.rawDashboards)

--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -19,6 +19,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 
     grafana+:: {
       dashboards: {},
+      rawDashboards: {},
       datasources: [{
         name: 'prometheus',
         type: 'prometheus',

--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -54,6 +54,15 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
 
         for name in std.objectFields($._config.grafana.dashboards)
       ],
+    rawDashboardDefinitions:
+      local configMap = k.core.v1.configMap;
+      [
+        local dashboardName = 'grafana-dashboard-' + std.strReplace(name, '.json', '');
+        configMap.new(dashboardName, { [name]: $._config.grafana.rawDashboards[name]}) +
+        configMap.mixin.metadata.withNamespace($._config.namespace)
+
+        for name in std.objectFields($._config.grafana.rawDashboards)
+      ],
     dashboardSources:
       local configMap = k.core.v1.configMap;
       local dashboardSources = import 'configs/dashboard-sources/dashboards.libsonnet';
@@ -123,6 +132,12 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           containerVolumeMount.new('grafana-dashboard-' + dashboardName, '/grafana-dashboard-definitions/0/' + dashboardName)
           for name in std.objectFields($._config.grafana.dashboards)
         ] +
+        [
+          local dashboardName = std.strReplace(name, '.json', '');
+          containerVolumeMount.new('grafana-dashboard-' + dashboardName, '/grafana-dashboard-definitions/0/' + dashboardName)
+          for name in std.objectFields($._config.grafana.rawDashboards)
+        ] +
+
         if std.length($._config.grafana.config) > 0 then [configVolumeMount] else [];
 
       local volumes =
@@ -136,6 +151,12 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
           volume.withName(dashboardName) +
           volume.mixin.configMap.withName(dashboardName)
           for name in std.objectFields($._config.grafana.dashboards)
+        ] +
+        [
+          local dashboardName = 'grafana-dashboard-' + std.strReplace(name, '.json', '');
+          volume.withName(dashboardName) +
+          volume.mixin.configMap.withName(dashboardName)
+          for name in std.objectFields($._config.grafana.rawDashboards)
         ] +
         if std.length($._config.grafana.config) > 0 then [configVolume] else [];
 


### PR DESCRIPTION
So we have more than 66 dashboards and they are all raw JSON. exported from Grafana UI.
and it takes around 20 min to deploy grafana because of that.  And the culprit is this
https://github.com/brancz/kubernetes-grafana/blob/master/grafana/grafana.libsonnet#L52 (std.manifestJsonEx($._config.grafana.dashboards[name], '    ') }) ).
To indent json its taking whole lot of time. and its eaisly reproducible(just add 3-4 dashboard and you will see an increase in jsonnet time).

So to solve that problem for raw JSON dashboards I have added a new field called `rawGrafanaDashboards` which expects raw JSON value(string JSON value). so insisted of using `import` for this kind of dashboard just use `importstr`
```
  'k8s-cluster-dashboard-thanos.json': (importstr 'thanos/all-nodes.json'),
  'istio-gallery-dashboard-thanos.json': (importstr 'thanos/istio-gallery.json'),
  'istio-mesh-dashboard-thanos.json': (importstr 'thanos/istio-mesh.json'),
  'istio-mixer-dashboard-thanos.json': (importstr 'thanos/istio-mixer.json'),
  'istio-pilot-dashboard-thanos.json': (importstr 'thanos/istio-pilot.json'),
```

*now after this insisted of taking 20 min it takes less than 1 min. to render the whole deployment.*