### PR TITLE
Add fsGroup to securityContext

### DIFF
--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -237,6 +237,7 @@ local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
       deployment.mixin.spec.template.spec.withVolumes(volumes) +
       deployment.mixin.spec.template.spec.securityContext.withRunAsNonRoot(true) +
       deployment.mixin.spec.template.spec.securityContext.withRunAsUser(65534) +
+      deployment.mixin.spec.template.spec.securityContext.withFsGroup(65534) +
       deployment.mixin.spec.template.spec.withServiceAccountName('grafana'),
   },
 }


### PR DESCRIPTION
I think it's good practice to have this set along with the user. I had to set it anyway to make the token provided by IRSA readable in AWS EKS.