### PR TITLE
Use absolute jsonnet imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ An example of how to use it could be:
 
 [embedmd]:# (examples/basic.jsonnet)
 ```jsonnet
-local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 local service = k.core.v1.service;
 local servicePort = k.core.v1.service.mixin.spec.portsType;
 
@@ -81,11 +81,11 @@ This setup is optimized to work best when Grafana is used declaratively, so when
 
 [embedmd]:# (examples/dashboard-definition.jsonnet)
 ```jsonnet
-local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 local service = k.core.v1.service;
 local servicePort = k.core.v1.service.mixin.spec.portsType;
 
-local grafana = import 'grafonnet/grafana.libsonnet';
+local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
 local dashboard = grafana.dashboard;
 local row = grafana.row;
 local prometheus = grafana.prometheus;
@@ -147,7 +147,7 @@ If you have many dashboards and would like to organize them into folders, you ca
 
 [embedmd]:# (examples/dashboard-folder-definition.jsonnet)
 ```jsonnet
-local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 local service = k.core.v1.service;
 local servicePort = k.core.v1.service.mixin.spec.portsType;
 
@@ -211,7 +211,7 @@ And apply the mixin:
 
 [embedmd]:# (examples/basic-with-mixin.jsonnet)
 ```jsonnet
-local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 local service = k.core.v1.service;
 local servicePort = k.core.v1.service.mixin.spec.portsType;
 
@@ -258,7 +258,7 @@ For example to modify Grafana configuration and set up LDAP use:
 
 [embedmd]:# (examples/custom-ini.jsonnet)
 ```jsonnet
-local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 local service = k.core.v1.service;
 local servicePort = k.core.v1.service.mixin.spec.portsType;
 
@@ -316,7 +316,7 @@ The config object allows specifying an array of plugins to install at startup.
 
 [embedmd]:# (examples/plugins.jsonnet)
 ```jsonnet
-local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 local service = k.core.v1.service;
 local servicePort = k.core.v1.service.mixin.spec.portsType;
 

--- a/examples/basic-with-image-renderer.jsonnet
+++ b/examples/basic-with-image-renderer.jsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
+local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 local container = k.apps.v1.deployment.mixin.spec.template.spec.containersType;
 local env = container.envType;
 local containerPort = container.portsType;

--- a/examples/basic-with-mixin.jsonnet
+++ b/examples/basic-with-mixin.jsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 local service = k.core.v1.service;
 local servicePort = k.core.v1.service.mixin.spec.portsType;
 

--- a/examples/basic.jsonnet
+++ b/examples/basic.jsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 local service = k.core.v1.service;
 local servicePort = k.core.v1.service.mixin.spec.portsType;
 

--- a/examples/custom-ini.jsonnet
+++ b/examples/custom-ini.jsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 local service = k.core.v1.service;
 local servicePort = k.core.v1.service.mixin.spec.portsType;
 

--- a/examples/dashboard-definition.jsonnet
+++ b/examples/dashboard-definition.jsonnet
@@ -1,8 +1,8 @@
-local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 local service = k.core.v1.service;
 local servicePort = k.core.v1.service.mixin.spec.portsType;
 
-local grafana = import 'grafonnet/grafana.libsonnet';
+local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
 local dashboard = grafana.dashboard;
 local row = grafana.row;
 local prometheus = grafana.prometheus;

--- a/examples/dashboard-folder-definition.jsonnet
+++ b/examples/dashboard-folder-definition.jsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 local service = k.core.v1.service;
 local servicePort = k.core.v1.service.mixin.spec.portsType;
 

--- a/examples/plugins.jsonnet
+++ b/examples/plugins.jsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet/ksonnet.beta.3/k.libsonnet';
+local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 local service = k.core.v1.service;
 local servicePort = k.core.v1.service.mixin.spec.portsType;
 

--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -1,4 +1,4 @@
-local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
+local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
 
 {
   _config+:: {

--- a/grafana/jsonnetfile.json
+++ b/grafana/jsonnetfile.json
@@ -1,19 +1,19 @@
 {
+  "version": 1,
   "dependencies": [
     {
       "source": {
         "git": {
-          "remote": "https://github.com/grafana/grafonnet-lib",
+          "remote": "https://github.com/grafana/grafonnet-lib.git",
           "subdir": "grafonnet"
         }
       },
-      "version": "master",
-      "name": "grafonnet"
+      "version": "master"
     },
     {
       "source": {
         "git": {
-          "remote": "https://github.com/ksonnet/ksonnet-lib",
+          "remote": "https://github.com/ksonnet/ksonnet-lib.git",
           "subdir": ""
         }
       },
@@ -21,5 +21,5 @@
       "name": "ksonnet"
     }
   ],
-  "legacyImports": true
+  "legacyImports": false
 }


### PR DESCRIPTION
Start using absolute import paths to be able to disable legacy imports in projects import this one.
https://github.com/prometheus-operator/kube-prometheus/pull/675