### PR TITLE
Restructure to not use ksonnet

### DIFF
--- a/examples/basic-with-image-renderer.jsonnet
+++ b/examples/basic-with-image-renderer.jsonnet
@@ -1,53 +1,59 @@
-local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
-local container = k.apps.v1.deployment.mixin.spec.template.spec.containersType;
-local env = container.envType;
-local containerPort = container.portsType;
-local service = k.core.v1.service;
-local servicePort = k.core.v1.service.mixin.spec.portsType;
+local grafana = import 'grafana/grafana.libsonnet';
 
-local grafana = ((import 'grafana/grafana.libsonnet') + {
-                   _config+:: {
-                     namespace: 'monitoring-grafana',
-                     versions+:: {
-                       grafanaImageRenderer: '1.0.9',
-                     },
+local basicWithImageRenderer =
+  (grafana {
+     _config+:: {
+       namespace: 'monitoring-grafana',
+       versions+:: {
+         grafanaImageRenderer: '1.0.9',
+       },
 
-                     imageRepos+:: {
-                       grafanaImageRenderer: 'grafana/grafana-image-renderer',
-                     },
+       imageRepos+:: {
+         grafanaImageRenderer: 'grafana/grafana-image-renderer',
+       },
 
-                     grafana+:: {
-                       imageRendererPort: 8081,
-                       imageRendererContainer: {
-                         requests: { cpu: '100m', memory: '100Mi' },
-                         limits: { cpu: '200m', memory: '200Mi' },
-                       },
+       grafana+:: {
+         imageRendererPort: 8081,
+         imageRendererContainer: {
+           requests: { cpu: '100m', memory: '100Mi' },
+           limits: { cpu: '200m', memory: '200Mi' },
+         },
 
-                       env+: [
-                         env.new('GF_RENDERING_SERVER_URL', 'http://localhost:' + $._config.grafana.imageRendererPort + '/render'),
-                         env.new('GF_RENDERING_CALLBACK_URL', 'http://localhost:' + $._config.grafana.port),
-                       ],
+         env+: [
+           { name: 'GF_RENDERING_SERVER_URL', value: 'http://localhost:' + $._config.grafana.imageRendererPort + '/render' },
+           { name: 'GF_RENDERING_CALLBACK_URL', value: 'http://localhost:' + $._config.grafana.port },
+         ],
 
-                       containers+: [
-                         local volume = k.apps.v1.deployment.mixin.spec.template.spec.volumesType;
-                           container.new('grafana-image-renderer', $._config.imageRepos.grafanaImageRenderer + ':' + $._config.versions.grafanaImageRenderer) +
-                           container.withPorts(containerPort.newNamed($._config.grafana.imageRendererPort, 'http')) +
-                           container.mixin.resources.withRequests($._config.grafana.imageRendererContainer.requests) +
-                           container.mixin.resources.withLimits($._config.grafana.imageRendererContainer.limits),
-                       ],
-                     },
-                   },
-                 }).grafana;
+         containers+: [
+           {
+             name: 'grafana-image-renderer',
+             image: $._config.imageRepos.grafanaImageRenderer + ':' + $._config.versions.grafanaImageRenderer,
+             ports: [{ name: 'http', containerPort: $._config.grafana.imageRendererPort }],
+             resources: {
+               requests: $._config.grafana.imageRendererContainer.requests,
+               limits: $._config.grafana.imageRendererContainer.limits,
+             },
+           },
+         ],
+       },
+     },
+   }).grafana;
 
-k.core.v1.list.new(
-  grafana.dashboardDefinitions +
-  [
-    grafana.dashboardSources,
-    grafana.dashboardDatasources,
-    grafana.deployment,
-    grafana.serviceAccount,
-    grafana.service +
-    service.mixin.spec.withPorts(servicePort.newNamed('http', 3000, 'http') + servicePort.withNodePort(30910)) +
-    service.mixin.spec.withType('NodePort'),
-  ]
-)
+{
+  apiVersion: 'v1',
+  kind: 'List',
+  items: [
+    basicWithImageRenderer.dashboardSources,
+    basicWithImageRenderer.dashboardDatasources,
+    basicWithImageRenderer.deployment,
+    basicWithImageRenderer.serviceAccount,
+    basicWithImageRenderer.service {
+      spec+: { ports: [
+        port {
+          nodePort: 30910,
+        }
+        for port in super.ports
+      ] },
+    },
+  ],
+}

--- a/examples/basic.jsonnet
+++ b/examples/basic.jsonnet
@@ -1,22 +1,29 @@
-local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
-local service = k.core.v1.service;
-local servicePort = k.core.v1.service.mixin.spec.portsType;
+local grafana = import 'grafana/grafana.libsonnet';
 
-local grafana = ((import 'grafana/grafana.libsonnet') + {
-                   _config+:: {
-                     namespace: 'monitoring-grafana',
-                   },
-                 }).grafana;
+{
+  local basic =
+    (grafana {
+       _config+:: {
+         namespace: 'monitoring-grafana',
+       },
+     }).grafana,
 
-k.core.v1.list.new(
-  grafana.dashboardDefinitions +
-  [
-    grafana.dashboardSources,
-    grafana.dashboardDatasources,
-    grafana.deployment,
-    grafana.serviceAccount,
-    grafana.service +
-    service.mixin.spec.withPorts(servicePort.newNamed('http', 3000, 'http') + servicePort.withNodePort(30910)) +
-    service.mixin.spec.withType('NodePort'),
-  ]
-)
+  apiVersion: 'v1',
+  kind: 'List',
+  items:
+    basic.dashboardDefinitions +
+    [
+      basic.dashboardSources,
+      basic.dashboardDatasources,
+      basic.deployment,
+      basic.serviceAccount,
+      basic.service {
+        spec+: { ports: [
+          port {
+            nodePort: 30910,
+          }
+          for port in super.ports
+        ] },
+      },
+    ],
+}

--- a/examples/custom-ini.jsonnet
+++ b/examples/custom-ini.jsonnet
@@ -1,50 +1,57 @@
-local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
-local service = k.core.v1.service;
-local servicePort = k.core.v1.service.mixin.spec.portsType;
+local grafana = import 'grafana/grafana.libsonnet';
 
-local grafana = ((import 'grafana/grafana.libsonnet') + {
-                   _config+:: {
-                     namespace: 'monitoring-grafana',
-                     grafana+:: {
-                       config: {
-                         sections: {
-                           metrics: { enabled: true },
-                           'auth.ldap': {
-                             enabled: true,
-                             config_file: '/etc/grafana/ldap.toml',
-                             allow_sign_up: true,
-                           },
-                         },
-                       },
-                       ldap: |||
-                         [[servers]]
-                         host = "127.0.0.1"
-                         port = 389
-                         use_ssl = false
-                         start_tls = false
-                         ssl_skip_verify = false
+{
+  local customIni =
+    (grafana {
+       _config+:: {
+         namespace: 'monitoring-grafana',
+         grafana+:: {
+           config: {
+             sections: {
+               metrics: { enabled: true },
+               'auth.ldap': {
+                 enabled: true,
+                 config_file: '/etc/grafana/ldap.toml',
+                 allow_sign_up: true,
+               },
+             },
+           },
+           ldap: |||
+             [[servers]]
+             host = "127.0.0.1"
+             port = 389
+             use_ssl = false
+             start_tls = false
+             ssl_skip_verify = false
 
-                         bind_dn = "cn=admin,dc=grafana,dc=org"
-                         bind_password = 'grafana'
+             bind_dn = "cn=admin,dc=grafana,dc=org"
+             bind_password = 'grafana'
 
-                         search_filter = "(cn=%s)"
+             search_filter = "(cn=%s)"
 
-                         search_base_dns = ["dc=grafana,dc=org"]
-                       |||,
-                     },
-                   },
-                 }).grafana;
+             search_base_dns = ["dc=grafana,dc=org"]
+           |||,
+         },
+       },
+     }).grafana,
 
-k.core.v1.list.new(
-  grafana.dashboardDefinitions +
-  [
-    grafana.config,
-    grafana.dashboardSources,
-    grafana.dashboardDatasources,
-    grafana.deployment,
-    grafana.serviceAccount,
-    grafana.service +
-    service.mixin.spec.withPorts(servicePort.newNamed('http', 3000, 'http') + servicePort.withNodePort(30910)) +
-    service.mixin.spec.withType('NodePort'),
-  ]
-)
+  apiVersion: 'v1',
+  kind: 'List',
+  items:
+    customIni.dashboardDefinitions +
+    [
+      customIni.config,
+      customIni.dashboardSources,
+      customIni.dashboardDatasources,
+      customIni.deployment,
+      customIni.serviceAccount,
+      customIni.service {
+        spec+: { ports: [
+          port {
+            nodePort: 30910,
+          }
+          for port in super.ports
+        ] },
+      },
+    ],
+}

--- a/examples/dashboard-definition.jsonnet
+++ b/examples/dashboard-definition.jsonnet
@@ -1,7 +1,3 @@
-local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
-local service = k.core.v1.service;
-local servicePort = k.core.v1.service.mixin.spec.portsType;
-
 local grafana = import 'github.com/grafana/grafonnet-lib/grafonnet/grafana.libsonnet';
 local dashboard = grafana.dashboard;
 local row = grafana.row;
@@ -9,8 +5,10 @@ local prometheus = grafana.prometheus;
 local template = grafana.template;
 local graphPanel = grafana.graphPanel;
 
-local grafana =
-  ((import 'grafana/grafana.libsonnet') +
+local grafana = import 'grafana/grafana.libsonnet';
+
+local grafanaWithDashboards =
+  (grafana
    {
      _config+:: {
        namespace: 'monitoring-grafana',
@@ -36,23 +34,33 @@ local grafana =
              )
              .addRow(
                row.new()
-               .addPanel(graphPanel.new('My Panel', span=6, datasource='$datasource')
-                         .addTarget(prometheus.target('vector(1)')))
+               .addPanel(
+                 graphPanel.new('My Panel', span=6, datasource='$datasource')
+                 .addTarget(prometheus.target('vector(1)')),
+               )
              ),
          },
        },
      },
    }).grafana;
 
-k.core.v1.list.new(
-  grafana.dashboardDefinitions +
-  [
-    grafana.dashboardSources,
-    grafana.dashboardDatasources,
-    grafana.deployment,
-    grafana.serviceAccount,
-    grafana.service +
-    service.mixin.spec.withPorts(servicePort.newNamed('http', 3000, 'http') + servicePort.withNodePort(30910)) +
-    service.mixin.spec.withType('NodePort'),
-  ]
-)
+{
+  apiVersion: 'v1',
+  kind: 'List',
+  items:
+    grafanaWithDashboards.dashboardDefinitions +
+    [
+      grafanaWithDashboards.dashboardSources,
+      grafanaWithDashboards.dashboardDatasources,
+      grafanaWithDashboards.deployment,
+      grafanaWithDashboards.serviceAccount,
+      grafanaWithDashboards.service {
+        spec+: { ports: [
+          port {
+            nodePort: 30910,
+          }
+          for port in super.ports
+        ] },
+      },
+    ],
+}

--- a/examples/plugins.jsonnet
+++ b/examples/plugins.jsonnet
@@ -1,25 +1,32 @@
-local k = import 'github.com/ksonnet/ksonnet-lib/ksonnet.beta.4/k.libsonnet';
-local service = k.core.v1.service;
-local servicePort = k.core.v1.service.mixin.spec.portsType;
+local grafana = import 'grafana/grafana.libsonnet';
 
-local grafana = ((import 'grafana/grafana.libsonnet') + {
-                   _config+:: {
-                     namespace: 'monitoring-grafana',
-                     grafana+:: {
-                       plugins: ['camptocamp-prometheus-alertmanager-datasource'],
-                     },
-                   },
-                 }).grafana;
+{
+  local basic =
+    (grafana {
+       _config+:: {
+         namespace: 'monitoring-grafana',
+         grafana+:: {
+           plugins: ['camptocamp-prometheus-alertmanager-datasource'],
+         },
+       },
+     }).grafana,
 
-k.core.v1.list.new(
-  grafana.dashboardDefinitions +
-  [
-    grafana.dashboardSources,
-    grafana.dashboardDatasources,
-    grafana.deployment,
-    grafana.serviceAccount,
-    grafana.service +
-    service.mixin.spec.withPorts(servicePort.newNamed('http', 3000, 'http') + servicePort.withNodePort(30910)) +
-    service.mixin.spec.withType('NodePort'),
-  ]
-)
+  apiVersion: 'v1',
+  kind: 'List',
+  items:
+    basic.dashboardDefinitions +
+    [
+      basic.dashboardSources,
+      basic.dashboardDatasources,
+      basic.deployment,
+      basic.serviceAccount,
+      basic.service {
+        spec+: { ports: [
+          port {
+            nodePort: 30910,
+          }
+          for port in super.ports
+        ] },
+      },
+    ],
+}

--- a/grafana/jsonnetfile.json
+++ b/grafana/jsonnetfile.json
@@ -9,16 +9,6 @@
         }
       },
       "version": "master"
-    },
-    {
-      "source": {
-        "git": {
-          "remote": "https://github.com/ksonnet/ksonnet-lib.git",
-          "subdir": ""
-        }
-      },
-      "version": "master",
-      "name": "ksonnet"
     }
   ],
   "legacyImports": false


### PR DESCRIPTION
ksonnet isn't needed anymore, going forward.
I tested these new objects by generating a YAML diff with the old output vs the new ones. 