### PR TITLE
Add dashboard definitions md5 to deployment annotations

### DIFF
--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -317,6 +317,7 @@
               annotations: {
                 [if std.length($._config.grafana.config) > 0 then 'checksum/grafana-config']: std.md5(std.toString($.grafana.config)),
                 'checksum/grafana-datasources': std.md5(std.toString($.grafana.dashboardDatasources)),
+                'checksum/grafana-dashboards': std.md5(std.toString($.grafana.dashboardDefinitions)),
               },
             },
             spec: {


### PR DESCRIPTION
By annotation dashboard definitions md5, changing dashboard definitions triggers redeployment.

Close https://github.com/brancz/kubernetes-grafana/issues/106.