### PR TITLE
Use full URL of the image

### DIFF
--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -7,7 +7,7 @@
     },
 
     imageRepos+:: {
-      grafana: 'grafana/grafana',
+      grafana: 'docker.io/grafana/grafana',
     },
 
     prometheus+:: {


### PR DESCRIPTION
Container runtimes try to pull unqualified images 
from a list of registries in `/etc/containers/registries.conf`.
An attacker can claim to be `grafana` on a registry
that comes before `docker.io` in the list, which leads to
pulling an unexpected image.