### PR TITLE
Revert the service type back to it's default (ClusterIP)

### DIFF
--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -180,7 +180,6 @@
         },
         spec: {
           selector: $.grafana.deployment.spec.selector.matchLabels,
-          type: 'NodePort',
           ports: [
             { name: 'http', targetPort: 'http', port: 3000 },
           ],


### PR DESCRIPTION
According to #102 the switch to NodePort was a mistake, this PR reverts it back to it's default value : ClusterIP.

Closes #102 