### PR TITLE
Allow setting folderUid

### DIFF
--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -24,6 +24,7 @@
       dashboards: {},
       rawDashboards: {},
       folderDashboards: {},
+      folderUidGenerator(folder): '',
       datasources: [{
         name: 'prometheus',
         type: 'prometheus',
@@ -123,6 +124,7 @@
                 name: '0',
                 orgId: 1,
                 folder: 'Default',
+                folderUid: $._config.grafana.folderUidGenerator('Default'),
                 type: 'file',
                 options: {
                   path: '/grafana-dashboard-definitions/0',
@@ -135,6 +137,7 @@
               name: folder,
               orgId: 1,
               folder: folder,
+              folderUid: $._config.grafana.folderUidGenerator(folder),
               type: 'file',
               options: {
                 path: '/grafana-dashboard-definitions/' + folder,
@@ -333,6 +336,7 @@
                 [if std.length($._config.grafana.config) > 0 then 'checksum/grafana-config']: std.md5(std.toString($.grafana.config)),
                 'checksum/grafana-datasources': std.md5(std.toString($.grafana.dashboardDatasources)),
                 [if $._config.grafana.dashboardsChecksum then 'checksum/grafana-dashboards']: std.md5(std.toString($.grafana.dashboardDefinitions)),
+                'checksum/grafana-dashboardproviders': std.md5(std.toString($.grafana.dashboardSources)),
               },
             },
             spec: {


### PR DESCRIPTION
When running a deployment with more that one replica, the generated dashboard folder UIDs can be different per instance. This creates inconsistent behavior when using the "Go to folder" links in `/dashboards/` as, depending on which instance the request hits, the user might get a "Folder not found" error.

The new `folderUidGenerator` function can be overriden to generate consistent folder UIDs by setting `folderUid` in the dashboard provider (docs [here][docs], example below). The default behavior of not setting a UID was maintained to not break expectations.

Additionally, I noticed while testing this feature that Grafana only loads the dashboard providers on startup, so I added a checksum for the providers configmap.

```jsonnet
local grafana = import 'grafana/grafana.libsonnet';

local grafanaWithDashboards =
  (grafana
   {
     _config+:: {
       namespace: 'monitoring-grafana',
       grafana+:: {
         folderDashboards+:: (import 'dashboard_folders.libsonnet'),
         folderUidGenerator(folder):: std.md5(folder),
       },
     },
   }).grafana;

{
  apiVersion: 'v1',
  kind: 'List',
  items:
    grafanaWithDashboards.dashboardDefinitions +
    [
      grafanaWithDashboards.dashboardSources,
      grafanaWithDashboards.dashboardDatasources,
      grafanaWithDashboards.deployment {
        spec+: { replicas: 3 },
      },
      grafanaWithDashboards.serviceAccount,
      grafanaWithDashboards.service,
    ],
}
```

[docs]: https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards