### PR TITLE
grafana/grafana.libsonnet: Update nodeSelector label to kubernetes.io/os

### DIFF
--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -339,7 +339,7 @@
               containers: c,
               volumes: volumes,
               serviceAccountName: $.grafana.serviceAccount.metadata.name,
-              nodeSelector: { 'beta.kubernetes.io/os': 'linux' },
+              nodeSelector: { 'kubernetes.io/os': 'linux' },
               securityContext: { fsGroup: 65534, runAsNonRoot: true, runAsUser: 65534 },
             },
           },


### PR DESCRIPTION
To fix the warning

```
spec.template.spec.nodeSelector[beta.kubernetes.io/os]: deprecated since v1.14; use "kubernetes.io/os" instead
```

@brancz @paulfantom Please review