### PR TITLE
Disable automounting SA token

### DIFF
--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -59,6 +59,7 @@ function(params) {
     apiVersion: 'v1',
     kind: 'ServiceAccount',
     metadata: g._metadata,
+    automountServiceAccountToken: false,
   },
 
   service: {


### PR DESCRIPTION
Part of initiative to increase security of kube-prometheus (https://github.com/prometheus-operator/kube-prometheus/issues/1589)