### PR TITLE
jsonnet: Forbid write access to root filesystem

### DIFF
--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -235,7 +235,9 @@ function(params) {
     // A volume on /tmp is needed to let us use 'readOnlyRootFilesystem: true'
     local pluginTmpVolume = {
       name: 'tmp-plugins',
-      emptyDir: {},
+      emptyDir: {
+        medium: 'Memory',
+      },
     };
     local pluginTmpVolumeMount = {
       mountPath: '/tmp',

--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -320,6 +320,7 @@ function(params) {
       securityContext: {
         capabilities: { drop: ['ALL'] },
         allowPrivilegeEscalation: false,
+        readOnlyRootFilesystem: true,
       },
     };
 

--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -232,12 +232,23 @@ function(params) {
       mountPath: '/etc/grafana/provisioning/dashboards',
       readOnly: false,
     };
+    // A volume on /tmp is needed to let us use 'readOnlyRootFilesystem: true'
+    local pluginTmpVolume = {
+      name: 'tmp-plugins',
+      emptyDir: {},
+    };
+    local pluginTmpVolumeMount = {
+      mountPath: '/tmp',
+      name: 'tmp-plugins',
+      readOnly: false,
+    };
 
     local volumeMounts =
       [
         storageVolumeMount,
         datasourcesVolumeMount,
         dashboardsVolumeMount,
+        pluginTmpVolumeMount,
       ] +
       [
         {
@@ -266,6 +277,7 @@ function(params) {
         storageVolume,
         datasourcesVolume,
         dashboardsVolume,
+        pluginTmpVolume,
       ] +
       [
         {


### PR DESCRIPTION
This is part of the initiative to tighten security in kube-prometheus - prometheus-operator/kube-prometheus#1595.

An attacker who has access to a container, can create files and download scripts as he wishes, and modify the underlying application running on the container. If a container, e.g. grafana, needs to write to the filesystem, a strict volume mount should be used.

Following remediation docs from https://hub.armo.cloud/docs/c-0017