### PR TITLE
grafana.libsonnet: Drop all linux capabilities

### DIFF
--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -317,6 +317,9 @@ function(params) {
         },
       },
       resources: g._config.resources,
+      securityContext: {
+        capabilities: { drop: ['ALL'] },
+      },
     };
 
     {


### PR DESCRIPTION
This is part of the initiative to tighten security in kube-prometheus

We're reducing the attack surface by dropping all Linux capabilities since Grafana doesn't need any to run smoothly

Following remediation docs from https://hub.armo.cloud/docs/c-0055