### PR TITLE
Set securityContext.seccompProfile.type to RuntimeDefault

### DIFF
--- a/grafana/grafana.libsonnet
+++ b/grafana/grafana.libsonnet
@@ -335,6 +335,7 @@ function(params) {
         capabilities: { drop: ['ALL'] },
         allowPrivilegeEscalation: false,
         readOnlyRootFilesystem: true,
+        seccompProfile: { type: 'RuntimeDefault' },
       },
     };
 


### PR DESCRIPTION
Deploying the kube-prometheus stack on Kubernetes v1.26 results in this warning:
```
Warning: would violate PodSecurity "restricted:latest": seccompProfile (pod or container "grafana" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```